### PR TITLE
Atualização do arquivo gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Ignorar todos os arquivos da pasta de avatars menos a imagem padrão
+public/images/avatars/*
+!public/images/avatars/default.png


### PR DESCRIPTION
Gitignore agora ignora todos os avatars enviados para o app mas mantém o avatar padrão